### PR TITLE
Added OpenCL to packages to install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 apt update
-apt install -y ubuntu-drivers-common apache2-utils nginx
+apt install -y ubuntu-drivers-common apache2-utils nginx ocl-icd-opencl-dev
 
 export DEBIAN_FRONTEND=noninteractive
 export DEBCONF_NONINTERACTIVE_SEEN=true


### PR DESCRIPTION
Ran into an issue where OpenCL wasn't being picked up on the Ubuntu LTS image, explicitly adding the package 'ocl-icd-opencl-dev' solved this. Repo'ed on an NV12.